### PR TITLE
fix utf8 encoding on regexp match

### DIFF
--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -114,7 +114,7 @@ is_excluded(Path) ->
 
       lists:foldl(fun(_, true) -> true;
                      (RE, false) ->
-                      (re:run(Path, RE) =/= nomatch) orelse (filelib:is_regular (Path) /= true)
+                      (re:run(Path, RE, [unicode]) =/= nomatch) orelse (filelib:is_regular (Path) /= true)
                   end, false, KnownExcludes).
 
 copy(File, Source, Target) ->


### PR DESCRIPTION
Some deps (like yaws) contain files with utf8 filenames. calling re:run/2 on such string fails with badarg.
Adding `unicode` option fixes this issue.