### PR TITLE
Fix the needs_update call

### DIFF
--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -54,7 +54,7 @@ download_(Dir, {path, Path}, _State) ->
       ok ->
           ok;
       {error, R} ->
-          rebar_log:log(info, "fail to change mtime, reason=R", [R]),
+          rebar_log:log(info, "fail to change mtime, reason=~p ~n", [R]),
           ok
   end.
 

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -54,7 +54,8 @@ download_(Dir, {path, Path}, _State) ->
       ok ->
           ok;
       {error, R} ->
-          rebar_log:log(info, "fail to change mtime, reason=R", [R])
+          rebar_log:log(info, "fail to change mtime, reason=R", [R]),
+          ok
   end.
 
 

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -57,13 +57,13 @@ make_vsn(_Dir) ->
   {error, "Replacing version of type path not supported."}.
 
 needs_update(Dir, {path, Path, _} = E) ->
-  rebar_log:log(debug, "needs_update: ~p", [E]),
+  rebar_log:log(debug, "needs_update: E:~p", [E]),
   needs_update_(Dir, {path, Path});
-needs_update(AppInfo, E) ->
-  rebar_log:log(debug, "needs_update: ~p", [E]),
+needs_update(AppInfo, S) ->
+  rebar_log:log(debug, "needs_update: S:~p", [S]),
   needs_update_(rebar_app_info:dir(AppInfo), rebar_app_info:source(AppInfo)).
 
-needs_update_(Dir, {path, Path}) ->
+needs_update_(Dir, {path, Path, _}) ->
   {ok, Cwd} = file:get_cwd(),
   Source = filename:join([Cwd, Path]),
   LastModified = last_modified(Source),
@@ -71,7 +71,7 @@ needs_update_(Dir, {path, Path}) ->
   rebar_log:log(debug, "compare dir=~p, path=~p last modified=~p, old=~p~n", [Dir, Path, LastModified, Old]),
   (Old < LastModified);
 needs_update_(_, E) ->
-  rebar_log:log(debug, "needs_update: ~p", [E]),
+  rebar_log:log(debug, "needs_update_: ~p", [E]),
   true = false.
 
 

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -56,18 +56,23 @@ download_(Dir, {path, Path}, _State) ->
 make_vsn(_Dir) ->
   {error, "Replacing version of type path not supported."}.
 
-needs_update(Dir, Path) ->
+needs_update(Dir, {path, Path, _} = E) ->
+  rebar_log:log(debug, "needs_update: ~p", [E]),
   needs_update_(Dir, {path, Path});
-needs_update(AppInfo, _) ->
+needs_update(AppInfo, E) ->
+  rebar_log:log(debug, "needs_update: ~p", [E]),
   needs_update_(rebar_app_info:dir(AppInfo), rebar_app_info:source(AppInfo)).
 
-needs_update_(Dir, {path, Path, _}) ->
+needs_update_(Dir, {path, Path}) ->
   {ok, Cwd} = file:get_cwd(),
   Source = filename:join([Cwd, Path]),
   LastModified = last_modified(Source),
   Old = filelib:last_modified(Dir),
   rebar_log:log(debug, "compare dir=~p, path=~p last modified=~p, old=~p~n", [Dir, Path, LastModified, Old]),
-  (Old < LastModified).
+  (Old < LastModified);
+needs_update_(_, E) ->
+  rebar_log:log(debug, "needs_update: ~p", [E]),
+  true = false.
 
 
 last_modified(Source) ->

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -67,11 +67,7 @@ needs_update_(Dir, {path, Path, _}) ->
   LastModified = last_modified(Source),
   Old = filelib:last_modified(Dir),
   rebar_log:log(debug, "compare dir=~p, path=~p last modified=~p, old=~p~n", [Dir, Path, LastModified, Old]),
-  (Old < LastModified);
-needs_update_(_, E) ->
-  rebar_log:log(debug, "needs_update_: ~p", [E]),
-  true = false.
-
+  (Old < LastModified).
 
 last_modified(Source) ->
   Files = filter_files(dir_files(Source)),

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -50,7 +50,12 @@ download_(Dir, {path, Path}, _State) ->
   rebar_log:log(debug, "copied source from=~p, to=~p ~n", [Path, Dir]),
   LastModified = last_modified(Source),
   {ok, A} = file:read_file_info(Dir),
-  file:write_file_info(Path, A#file_info{mtime = LastModified, atime = LastModified}).
+  case file:write_file_info(Path, A#file_info{mtime = LastModified, atime = LastModified}) of
+      ok ->
+          ok;
+      {error, R} ->
+          rebar_log:log(info, "fail to change mtime, reason=R", [R])
+  end.
 
 
 make_vsn(_Dir) ->

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -50,13 +50,7 @@ download_(Dir, {path, Path}, _State) ->
   rebar_log:log(debug, "copied source from=~p, to=~p ~n", [Path, Dir]),
   LastModified = last_modified(Source),
   {ok, A} = file:read_file_info(Dir),
-  case file:write_file_info(Path, A#file_info{mtime = LastModified, atime = LastModified}) of
-      ok ->
-          ok;
-      {error, R} ->
-          rebar_log:log(info, "fail to change mtime, reason=~p ~n", [R]),
-          ok
-  end.
+  file:write_file_info(Path, A#file_info{mtime = LastModified, atime = LastModified}).
 
 
 make_vsn(_Dir) ->

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -56,11 +56,9 @@ download_(Dir, {path, Path}, _State) ->
 make_vsn(_Dir) ->
   {error, "Replacing version of type path not supported."}.
 
-needs_update(Dir, {path, Path, _} = E) ->
-  rebar_log:log(debug, "needs_update: E:~p", [E]),
+needs_update(Dir, {path, Path, _}) ->
   needs_update_(Dir, {path, Path});
-needs_update(AppInfo, S) ->
-  rebar_log:log(debug, "needs_update: S:~p", [S]),
+needs_update(AppInfo, _) ->
   needs_update_(rebar_app_info:dir(AppInfo), rebar_app_info:source(AppInfo)).
 
 needs_update_(Dir, {path, Path, _}) ->

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -56,12 +56,12 @@ download_(Dir, {path, Path}, _State) ->
 make_vsn(_Dir) ->
   {error, "Replacing version of type path not supported."}.
 
-needs_update(Dir, {path, Path, _}) ->
+needs_update(Dir, Path) ->
   needs_update_(Dir, {path, Path});
 needs_update(AppInfo, _) ->
   needs_update_(rebar_app_info:dir(AppInfo), rebar_app_info:source(AppInfo)).
 
-needs_update_(Dir, {path, Path}) ->
+needs_update_(Dir, {path, Path, _}) ->
   {ok, Cwd} = file:get_cwd(),
   Source = filename:join([Cwd, Path]),
   LastModified = last_modified(Source),


### PR DESCRIPTION
Previously the `needs_update` function would always crash since the function head would never match. The error was silent because rebar3 does not log the error, it simply return `true`. This has been validate with rebar3 >= 3.14.3