### PR TITLE
Fix the problem with dependency recompilation

### DIFF
--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -59,11 +59,12 @@ make_vsn(_Dir) ->
 needs_update(Dir, {path, Path, _}) ->
   needs_update_(Dir, {path, Path});
 needs_update(AppInfo, _) ->
+  Dir = rebar_app_info:dir(AppInfo),
   case rebar_app_info:source(AppInfo) of
     {path, Path} ->
-      needs_update_(rebar_app_info:dir(AppInfo), {path, Path});
+      needs_update_(Dir, {path, Path});
     {path, Path, _} ->
-      needs_update_(rebar_app_info:dir(AppInfo), {path, Path})
+      needs_update_(Dir, {path, Path})
   end.
 
 needs_update_(Dir, {path, Path}) ->

--- a/src/rebar_path_resource.erl
+++ b/src/rebar_path_resource.erl
@@ -59,7 +59,12 @@ make_vsn(_Dir) ->
 needs_update(Dir, {path, Path, _}) ->
   needs_update_(Dir, {path, Path});
 needs_update(AppInfo, _) ->
-  needs_update_(rebar_app_info:dir(AppInfo), rebar_app_info:source(AppInfo)).
+  case rebar_app_info:source(AppInfo) of
+    {path, Path} ->
+      needs_update_(rebar_app_info:dir(AppInfo), {path, Path});
+    {path, Path, _} ->
+      needs_update_(rebar_app_info:dir(AppInfo), {path, Path})
+  end.
 
 needs_update_(Dir, {path, Path}) ->
   {ok, Cwd} = file:get_cwd(),


### PR DESCRIPTION
### Summary
The aim of this Pull Request is to fix a problem that causes all dependencies to be recompiled when using path dependencies.  

### Problem recreation

dependencies versions on which problem was observed and recreated:
- Rebar3: 3.19.0
- rebar3_path_deps: 0.4.0

1. Create umbrella application using Rebar3 templates
```
$ rebar3 new umbrella
===> Writing myapp/apps/myapp/src/myapp_app.erl
===> Writing myapp/apps/myapp/src/myapp_sup.erl
===> Writing myapp/apps/myapp/src/myapp.app.src
===> Writing myapp/rebar.config
===> Writing myapp/config/sys.config
===> Writing myapp/config/vm.args
===> Writing myapp/.gitignore
===> Writing myapp/LICENSE
===> Writing myapp/README.md
```
2. Access "myapp" directory
```
$ cd myapp
```
3. Create "custom_lib" directory and access it
```
myapp$ mkdir custom_lib"
myapp$ cd custom_lib
```
4. Create library using Rebar3 templates
```
myapp/custom_lib$ rebar3 new lib
===> Writing mylib/src/mylib.erl
===> Writing mylib/src/mylib.app.src
===> Writing mylib/rebar.config
===> Writing mylib/.gitignore
===> Writing mylib/LICENSE
===> Writing mylib/README.md
```
5. Go back to the mylib directory
```
myapp/custom_lib$ cd ..
```
6. Edit rebar.config file and put the following configuration
```
{deps, [
    {mylib, {path, "custom_lib/mylib"}},
    {cowboy, "2.12.0"}
]}.

{plugins, [rebar3_path_deps]}.
```
6. Compile the project
```
myapp$ rebar3 compile
===> Fetching rebar3_path_deps v0.4.0
===> Analyzing applications...
===> Compiling rebar3_path_deps
===> Verifying dependencies...
===> Fetching cowboy v2.12.0
===> Fetching mylib (from {path,"custom_lib/mylib"})
===> Fetching cowlib v2.13.0
===> Fetching ranch v1.8.0
===> Analyzing applications...
===> Compiling mylib
===> Compiling ranch
===> Compiling cowlib
===> Compiling cowboy
===> Analyzing applications...
===> Compiling myapp
```

7. Compile the project once more
```
myapp$ rebar3 compile
===> Verifying dependencies...
===> Upgrading mylib (from {path,"custom_lib/mylib",{mtime,<<"2024-08-07T01:11:38Z">>}})
===> Analyzing applications...
===> Compiling mylib
===> Compiling ranch
===> Compiling cowlib
===> Compiling cowboy
===> Analyzing applications...
===> Compiling myapp
```

It can be seen that despite the fact that there were no changes in the code all dependencies are recompiled - this includes both: custom library "mylib" (included based on the path using rebar3_path_deps plugin) and external library "cowboy".

### Analysis

Performing a compilation with debugging logs enabled indicated the problem
```
myapp$ DEBUG=1 rebar3 compile
...
===> Running provider: install_deps
===> Verifying dependencies...
===> Failed checking if dependency needs updates : error:function_clause
===> Upgrading mylib (from {path,"custom_lib/mylib",{mtime,<<"2024-08-07T01:11:38Z">>}})
===> copied source from="custom_lib/mylib", to="/tmp/.tmp_dir726335108557" 
...
```

Tracing using dbg module provided further information that the exception is raised during the execution of the rebar_resource_v2:resource_run/4 function in which the callback function rebar3_path_resource:needs_update/2 is executed, information about "source" and "dir" is extracted from the AppInfo argument and these values are passed to rebar3_path_resource:needs_update_/2 function. This is the place where the function_clause error is raised. This function expects the second argument to be in format {path, _}
```
needs_update_(Dir, {path, Path}) ->
  ...
```
However in our case it has the a format of {path, _, _} e.g.
```
{path,"custom_lib/mylib",{mtime,<<"2024-08-07T01:11:38Z">>}
``` 
This is the root cause of the problem.


### Solution description

The function rebar_resource_v2:resource_run/4 is also used for executing the "download" operation which calls the rebar_path_resource:download/4 callback. This callback function has an appropriate case to include both formats of "source" value:
```
download(TmpDir, AppInfo, State, _) ->
  case rebar_app_info:source(AppInfo) of
    {path, Path} ->
      download_(TmpDir, {path, Path}, State);
    {path, Path, _} ->
      download_(TmpDir, {path, Path}, State)
  end.
```

In order to be consistent with the existing solution this Pull Request proposes including the same case in rebar_path_resource:needs_update/2 function:
```
needs_update(AppInfo, _) ->
  Dir = rebar_app_info:dir(AppInfo),
  case rebar_app_info:source(AppInfo) of
    {path, Path} ->
      needs_update_(Dir, {path, Path});
    {path, Path, _} ->
      needs_update_(Dir, {path, Path})
  end.
```

### Solution tests

The tests are performed on the same application that was used to recreate the problem.

1. Remove _build and rebar.lock
```
myapp$ rm -rf _build
myapp$ rm rebar.lock
```

2. Edit rebar.config file and put the following configuration
```
{deps, [
    {mylib, {path, "custom_lib/mylib"}},
    {cowboy, "2.12.0"}
]}.

{plugins, [{rebar3_path_deps, {git, "https://github.com/Kacpro/rebar3_path_deps.git", {branch, "master"}}}]}.
```

3. Compile the project
```
myapp$ rebar3 compile
===> Fetching rebar3_path_deps (from {git,"https://github.com/Kacpro/rebar3_path_deps.git",
                            {branch,"master"}})
===> Analyzing applications...
===> Compiling rebar3_path_deps
===> Verifying dependencies...
===> Fetching cowboy v2.12.0
===> Fetching mylib (from {path,"custom_lib/mylib"})
===> Fetching cowlib v2.13.0
===> Fetching ranch v1.8.0
===> Analyzing applications...
===> Compiling mylib
===> Compiling ranch
===> Compiling cowlib
===> Compiling cowboy
===> Analyzing applications...
===> Compiling myapp
```

4. Compile the project once more
```
myapp$ rebar3 compile
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling myapp
```

It can be seen that the dependencies are not recompiled which is the expected behavior.